### PR TITLE
Fixed error with ssl

### DIFF
--- a/bb-library/Server/Manager/Virtualmin.php
+++ b/bb-library/Server/Manager/Virtualmin.php
@@ -227,7 +227,7 @@ class Server_Manager_Virtualmin extends Server_Manager
      */
     private function _getUrl()
     {
-    	$url = $this->_config['ssl'] ? 'https://' : 'http://';
+    	$url = $this->_config['host'] ? 'https://' : 'http://';
     	$url .= $this->_config['host'] . ' : ' . $this->_config['port'] . '/virtual-server/remote.cgi';
 
     	return $url;


### PR DESCRIPTION
Fixed error PHP Notice: Undefined index: ssl on line 230. Modifications based on test results and post on forums.

Tested and working.

- Orginal source -

> Arifta Adhca Fachrizal
> said

> I've been successfully connected to the server.
> I just change "ssl" to "host" at line 230 :
> Before :
> $url = $this->_config['ssl'] ? 'https://' : 'http://';
> To :
> $url = $this->_config['host'] ? 'https://' : 'http://';
> Then, I put my server IP address on "Hostname" at Server management.
> That's can fix my problem. You can try it.
> Sorry for my English.